### PR TITLE
Add i586 case to TOOLABI

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -709,7 +709,7 @@ evaltarget ()
 			MACHINE="amd64"
 		fi
 		;;
-	"i386"|"i486"|"i686")
+	"i386"|"i486"|"i586"|"i686")
 		check64
 		MACHINE="i386"
 		MACH_ARCH="i486"


### PR DESCRIPTION
Discovered this bug building rpm:s for Mandriva on OpenBuildService
