### PR TITLE
force non thumb build if necessary on ARM

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -609,6 +609,14 @@ probearm ()
 	if ${CC} -E -dM - < /dev/null | grep -q __VFP_FP__; then
 		SOFTFLOAT='-V MKSOFTFLOAT=no'
 	fi
+
+	# A thumb build does not work due to assembler containing
+	# opcodes that are not permitted. If the environment defaults
+	# to thumb, force to full ARM instructions instead.
+	if ${CC} -E -dM - < /dev/null | grep -q __THUMBEL__; then
+                EXTRA_CFLAGS='-marm'
+                EXTRA_AFLAGS='-marm'
+	fi
 }
 
 evaltarget ()


### PR DESCRIPTION
This fixes the ARM build on recent Debian armhf (and possibly other) systems that default to thumb2 instruction set for ARM gcc. NetBSD does not currently compile in thumb mode, at least the assembly would need to be fixed. This leaves thumb interop on, so it can still be linked to thumb binaries...
