### PR TITLE
Fix build on Arch Linux with gcc 4.8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ your first pull request.
 Antti Kantee <pooka@iki.fi>
 Jens Staal <staal1978@gmail.com>
 Justin Cormack <justin@specialbusservice.com>
+Alessio Sergi <al3hex@gmail.com>

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ as follows:
     - Linux vyrnwy 3.6.2-1.fc16.x86_64 #1 SMP Wed Oct 17 05:30:01 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux (Fedora release 16 with read-only /usr/src via NFS)
     - Linux golden-valley 3.2.27-18-ARCH+ #1 PREEMPT Fri Dec 21 14:18:42 UTC 2012 armv6l GNU/Linux (Arch, Raspberry Pi, evbarm)
     - Linux void-rpi 3.6.11_1 #1 PREEMPT Tue Feb 19 17:40:24 CET 2013 armv6l GNU/Linux (Void, Raspberry Pi, evbarm)
+    - Linux braniac 3.9.9-1-ARCH #1 SMP PREEMPT Wed Jul 3 22:45:16 CEST 2013 x86_64 GNU/Linux (Arch Linux, amd64, gcc 4.8.1)
 
 - DragonFly BSD
     - DragonFly  3.2-RELEASE DragonFly v3.2.1.9.g80b03f-RELEASE #2: Wed Oct 31 20:17:57 PDT 2012     root@pkgbox32.dragonflybsd.org:/usr/obj/build/home/justin/src/sys/GENERIC  i386

--- a/buildrump.sh
+++ b/buildrump.sh
@@ -224,6 +224,7 @@ maketools ()
 	cd ${OBJDIR}
 	cctestW 'no-unused-but-set-variable'
 	cctestW 'no-unused-local-typedefs'
+	cctestW 'no-maybe-uninitialized'
 
 	# The compiler cannot do %zd/u warnings if the NetBSD kernel
 	# uses the different flavor of size_t (int vs. long) than what


### PR DESCRIPTION
Avoid gcc 4.8 -Wmaybe-uninitialized warning
Add new tested host: Arch Linux, amd64, gcc 4.8.1
Add Alessio Sergi to AUTHORS
