### PR TITLE
Fix build with clang on FreeBSD

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -482,7 +482,7 @@ evaltools ()
 	*-dragonflybsd)
 		TARGET=dragonfly
 		;;
-	*-freebsd)
+	*-freebsd*)
 		TARGET=freebsd
 		;;
 	*-netbsd*)


### PR DESCRIPTION
In a nutshell:

``` sh
> clang -v
FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610
Target: x86_64-unknown-freebsd10.0
Thread model: posix

> gcc -v
Using built-in specs.
Target: amd64-undermydesk-freebsd
Configured with: FreeBSD/amd64 system compiler
Thread model: posix
gcc version 4.2.1 20070831 patched [FreeBSD]
```

It was a tough job, but someone had to do It ;-)
