### PR TITLE
Avoid another warning with gcc 4.8

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -228,6 +228,7 @@ maketools ()
 	cctestW 'no-unused-but-set-variable'
 	cctestW 'no-unused-local-typedefs'
 	cctestW 'no-maybe-uninitialized'
+	cctestW 'no-cpp'
 
 	# The compiler cannot do %zd/u warnings if the NetBSD kernel
 	# uses the different flavor of size_t (int vs. long) than what


### PR DESCRIPTION
While compiling I get this error:

```
In file included from /home/alessio/buildrump.sh/src/lib/librumphijack/../librumpuser/rumpuser_port.h:55:0,
                 from /home/alessio/buildrump.sh/src/lib/librumphijack/hijackdlsym.c:28:
/usr/include/features.h:330:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
cc1: all warnings being treated as errors
*** [hijackdlsym.pico] Error code 1
```

Fixed passing `-Wno-cpp`.
