### PR TITLE
Implement IPv6 SLAAC support for libnetconfig

### DIFF
--- a/brlib/libnetconfig/netconfig.ifspec
+++ b/brlib/libnetconfig/netconfig.ifspec
@@ -37,3 +37,6 @@ int	|netconfig_ipv6_gw	|const char *
 
 ; dhcp
 int	|netconfig_dhcp_ipv4_oneshot	|const char *
+
+; ipv6 autoconfiguration
+int	|netconfig_auto_ipv6	|const char *

--- a/brlib/libnetconfig/netconfig_if_priv.h
+++ b/brlib/libnetconfig/netconfig_if_priv.h
@@ -31,5 +31,7 @@ int rump_netconfig_ipv6_gw(const char *);
 typedef int (*rump_netconfig_ipv6_gw_fn)(const char *);
 int rump_netconfig_dhcp_ipv4_oneshot(const char *);
 typedef int (*rump_netconfig_dhcp_ipv4_oneshot_fn)(const char *);
+int rump_netconfig_auto_ipv6(const char *);
+typedef int (*rump_netconfig_auto_ipv6_fn)(const char *);
 
 #endif /* _RUMP_PRIF_NETCONFIG_H_ */

--- a/brlib/libnetconfig/netconfig_if_wrappers.c
+++ b/brlib/libnetconfig/netconfig_if_wrappers.c
@@ -154,3 +154,15 @@ rump_pub_netconfig_dhcp_ipv4_oneshot(const char *arg1)
 
 	return rv;
 }
+
+int
+rump_pub_netconfig_auto_ipv6(const char *arg1)
+{
+	int rv;
+
+	rump_schedule();
+	rv = rump_netconfig_auto_ipv6(arg1);
+	rump_unschedule();
+
+	return rv;
+}

--- a/brlib/libnetconfig/rump/netconfig.h
+++ b/brlib/libnetconfig/rump/netconfig.h
@@ -17,3 +17,4 @@ int rump_pub_netconfig_ipv6_ifaddr(const char *, const char *, int);
 int rump_pub_netconfig_ipv4_gw(const char *);
 int rump_pub_netconfig_ipv6_gw(const char *);
 int rump_pub_netconfig_dhcp_ipv4_oneshot(const char *);
+int rump_pub_netconfig_auto_ipv6(const char *);


### PR DESCRIPTION
Added the rump_netconfig_auto_ipv6() function which performs IPv6
stateless address autoconfiguration for the specified interface.

Preliminary support for changes in NetBSD HEAD, compile-tested only.