### PR TITLE
Fix the unrecognized warning error when building with (newer) clang

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Justin Cormack <justin@specialbusservice.com>
 Alessio Sergi <al3hex@gmail.com>
 Alexander Guy <alexander.guy@andern.org>
 Robert Millan <rmh@gnu.org>
+Viktor Pocedulic <viktor.pocedulic@gmail.com>

--- a/buildrump.sh
+++ b/buildrump.sh
@@ -295,6 +295,16 @@ checkcheckout ()
 checkcompiler ()
 {
 
+	# Iron out the clang version differences.
+	if [ "${CC_FLAVOR}" = 'clang' ]; then
+		doesitbuild 'int main(void) {return 0;}\n' -c \
+			-Wtautological-pointer-compare
+		if [ $? -ne 0 ]; then
+			appendvar_fs CCWRAPPER_MANGLE : \
+				"-Wno-error=tautological-pointer-compare -Wno-error=tautological-compare"
+		fi
+	fi
+
 	if ! ${KERNONLY}; then
 		doesitbuild 'int main(void) {return 0;}\n' \
 		    ${EXTRA_RUMPUSER} ${EXTRA_RUMPCOMMON}


### PR DESCRIPTION
This was a problem on, at least, FreeBSD 10.2 with clang 3.4.1.