### PR TITLE
initial support for building linux kernel with buildrump.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: c
+addons:
+  apt:
+    packages:
+      - bc
+      - libfuse-dev
+      - libarchive-dev
+      - xfsprogs
+      - btrfs-tools
 
 compiler:
   - gcc
@@ -8,6 +16,7 @@ sudo: false
 
 before_script:
   - ./buildrump.sh checkout
+  - ./buildrump.sh ${LINUX} checkout
 
 env:
   - NAME='static' LIBTYPE='MKPIC=no' BUILDTYPE='' TESTS='tests'
@@ -15,9 +24,11 @@ env:
   - NAME='debug' LIBTYPE='MKSTATICLIB=no' BUILDTYPE='-DDD' TESTS='tests'
   - NAME='release' LIBTYPE='MKSTATICLIB=no' BUILDTYPE='-r' TESTS='tests'
   - NAME='fibers' LIBTYPE='MKSTATICLIB=no' BUILDTYPE='-V RUMPUSER_THREADS=fiber -V RUMP_CURLWP=hypercall' TESTS=''
+  - NAME='dynamic' LIBTYPE='MKSTATICLIB=no' BUILDTYPE='' TESTS='tests' LINUX='-l ./lkl-linux'
+  - NAME='fibers' LIBTYPE='MKSTATICLIB=no' BUILDTYPE='-V RUMPUSER_THREADS=fiber -V RUMP_CURLWP=hypercall' TESTS='' LINUX='-l ./lkl-linux'
 
 script:
-  -  ./buildrump.sh -o obj.${NAME} -d rump.${NAME} -qq -j16 -V ${LIBTYPE} ${BUILDTYPE} fullbuild ${TESTS}
+  - ./buildrump.sh ${LINUX} -o obj.${NAME} -d rump.${NAME} -qq -j16 -V ${LIBTYPE} ${BUILDTYPE} fullbuild ${TESTS}
 
 notifications:
   irc:


### PR DESCRIPTION
This commit introduces a new options for buildrump.sh, which is '-l'
option to build Linux kernel. Linux kernel is based on Linux Kernel
Library (LKL) with not-upstreamed patches to implement with rump
hypercall interfaces.

Since LKL is not yet upstreamed and development is still ongoing, the
commit tries to minimize future modifications to this script
(buildrump.sh) by specifying interfaces to build Linux kernel.

Currently, when '-l' option is specified, NetBSD rump kernel code will
be also built in addition to Linux kernel build since Linux part
requires headers files (i.e., include/rump) to build it.

A few more travis tests are also added though it's only build tests at
this moment though.

Signed-off-by: Hajime Tazaki <thehajime@gmail.com>