### PR TITLE
Fix the GCC warning -Werror=shift-negative-value

### DIFF
--- a/brlib/libnetconfig/netconfig.c
+++ b/brlib/libnetconfig/netconfig.c
@@ -232,7 +232,7 @@ rump_netconfig_ipv4_ifaddr_cidr(const char *ifname, const char *addr,
 
 	if (mask < 0 || mask > 32)
 		return EINVAL;
-	return cfg_ipv4(ifname, addr, htonl(~0<<(32-mask)));
+	return cfg_ipv4(ifname, addr, htonl(~0U<<(32-mask)));
 }
 
 int


### PR DESCRIPTION
I am cross-compiling from Fedora 24 x86_64 to GNU Hurd i686 with GCC 6.1.0.  This compiler warning causes the build to fail.