### PR TITLE
Add  `NULL` definition when needed for `-lz` testing

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -531,9 +531,7 @@ maketools ()
 	# very confused if you start the build, it bombs, you add zlib,
 	# and retry.
 	doesitbuild_host '#include <zlib.h>
-#ifndef NULL
-#define NULL ((void *)0)
-#endif
+#include <stdlib.h>
 int main() {gzopen(NULL, NULL); return 0;}' -lz \
 	    || die 'Host zlib (libz, -lz) required, please install one!'
 

--- a/buildrump.sh
+++ b/buildrump.sh
@@ -531,6 +531,9 @@ maketools ()
 	# very confused if you start the build, it bombs, you add zlib,
 	# and retry.
 	doesitbuild_host '#include <zlib.h>
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
 int main() {gzopen(NULL, NULL); return 0;}' -lz \
 	    || die 'Host zlib (libz, -lz) required, please install one!'
 


### PR DESCRIPTION
On some platforms `NULL` is not being defined via including `zlib.h` so testing of `-lz` will fail for no valid reason.
Adding a `#if` makes sense (and fixes it).