### PR TITLE
Add  `stdlib.h` include file to include `NULL`'s definition.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Alexander Guy <alexander.guy@andern.org>
 Robert Millan <rmh@gnu.org>
 Viktor Pocedulic <viktor.pocedulic@gmail.com>
 David Michael <fedora.dm0@gmail.com>
+Mahdi Mokhtari <mmokhi@FreeBSD.org>

--- a/buildrump.sh
+++ b/buildrump.sh
@@ -531,6 +531,7 @@ maketools ()
 	# very confused if you start the build, it bombs, you add zlib,
 	# and retry.
 	doesitbuild_host '#include <zlib.h>
+#include <stdlib.h>
 int main() {gzopen(NULL, NULL); return 0;}' -lz \
 	    || die 'Host zlib (libz, -lz) required, please install one!'
 


### PR DESCRIPTION
On some platforms (FreeBSD 12.0 for example) `NULL` is not being defined
via including `zlib.h` so Adding a `#if` makes sense (and fixes them)

Add new entry to AUTHORS