### PR TITLE
Set a common value for $CC if a unspecified

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -362,6 +362,7 @@ probe_rumpuserbits ()
 		( export CFLAGS="${EXTRA_CFLAGS}"
 		  export LDFLAGS="${EXTRA_LDFLAGS}"
 		  export CPPFLAGS="${EXTRA_CPPFLAGS}"
+		  export CC="${CC}"
 		  cd ${BRTOOLDIR}/autoconf \
 		    && ${SRCDIR}/lib/librumpuser/configure \
 		      $( ! ${NATIVEBUILD} && echo --host ${CC_TARGET} ) )


### PR DESCRIPTION
If a value for $CC is not explicitly specified ensure that the same value is used both by buildrump.sh and lib/librumpuser/configure.

When two different compilers are installed in the system, e.g., Clang as cc and GCC as gcc, buildrump.sh will use CC=cc while lib/librumpuser/configure will use CC=gcc instead.