### PR TITLE
Specify -L and -R for rump library path.

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -580,6 +580,7 @@ BUILDRUMP_CPPFLAGS=--sysroot=\${BUILDRUMP_STAGE} -isystem =/usr/include
 BUILDRUMP_CPPFLAGS=-I\${BUILDRUMP_STAGE}/usr/include
 .endif
 BUILDRUMP_CPPFLAGS+=${EXTRA_CPPFLAGS}
+BUILDRUMP_LDFLAGS=-L\${BUILDRUMP_STAGE}/usr/lib -Wl,-R${DESTDIR}/lib
 LIBDO.pthread=_external
 INSTPRIV=-U
 AFLAGS+=-Wa,--noexecstack


### PR DESCRIPTION
Otherwise we get /usr/lib/librump.so on NetBSD, which is not right.