### PR TITLE
rumpnet_net now needs rumpdev for config_cfdriver_attach.

### DIFF
--- a/tests/dynamic/dynamic.c
+++ b/tests/dynamic/dynamic.c
@@ -17,6 +17,10 @@ main()
 	int s;
 
 	/* use this as a "do we have dynamic libs" test */
+	if (dlopen("librumpvfs.so", RTLD_LAZY | RTLD_GLOBAL) == NULL)
+		return 37;
+	if (dlopen("librumpdev.so", RTLD_LAZY | RTLD_GLOBAL) == NULL)
+		return 37;
 	if (dlopen("librumpnet.so", RTLD_LAZY | RTLD_GLOBAL) == NULL)
 		return 37;
 

--- a/tests/nettest_routed/Makefile
+++ b/tests/nettest_routed/Makefile
@@ -1,7 +1,7 @@
 PROG= nettest_routed
 
 RUMPLIBS= -lrumpnet_shmif -lrumpnet_config -lrumpnet_netinet -lrumpnet_net
-RUMPLIBS+=-lrumpnet ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
+RUMPLIBS+=-lrumpnet -lrumpdev -lrumpvfs ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
 
 CLEANFILES+= busmem1 busmem2
 

--- a/tests/nettest_routed6/Makefile
+++ b/tests/nettest_routed6/Makefile
@@ -4,7 +4,7 @@ PROG= nettest_routed6
 SRCS= nettest_routed.c
 
 RUMPLIBS= -lrumpnet_shmif -lrumpnet_config -lrumpnet_netinet6 -lrumpnet_net
-RUMPLIBS+=-lrumpnet ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
+RUMPLIBS+=-lrumpnet -lrumpdev -lrumpvfs ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
 
 CLEANFILES+= busmem1 busmem2
 

--- a/tests/nettest_simple/Makefile
+++ b/tests/nettest_simple/Makefile
@@ -1,7 +1,7 @@
 PROG= nettest_simple
 
 RUMPLIBS= -lrumpnet_shmif -lrumpnet_config -lrumpnet_netinet -lrumpnet_net
-RUMPLIBS+=-lrumpnet ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
+RUMPLIBS+=-lrumpnet -lrumpdev -lrumpvfs ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
 
 CLEANFILES+= busmem
 

--- a/tests/nettest_simple6/Makefile
+++ b/tests/nettest_simple6/Makefile
@@ -4,7 +4,7 @@ PROG= nettest_simple6
 SRCS= nettest_simple.c
 
 RUMPLIBS= -lrumpnet_shmif -lrumpnet_config -lrumpnet_netinet6 -lrumpnet_net
-RUMPLIBS+=-lrumpnet ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
+RUMPLIBS+=-lrumpnet -lrumpdev -lrumpvfs ${RUMPKERN_SYSPROXY} -lrump -lrumpuser
 
 CLEANFILES+= busmem
 


### PR DESCRIPTION
rumpdev in turn needs rumpvfs.