### PR TITLE
Fix unbound variable DIRS_emul

### DIFF
--- a/buildrump.sh
+++ b/buildrump.sh
@@ -788,6 +788,8 @@ makebuild ()
 	     -o ${MACHINE#evbearm} != ${MACHINE} \
 	     -o ${MACHINE#evbppc} != ${MACHINE} ]; then
 		DIRS_emul=sys/rump/kern/lib/libsys_linux
+	else
+		DIRS_emul=
 	fi
 	${SYS_SUNOS} && appendvar DIRS_emul sys/rump/kern/lib/libsys_sunos
 	if ${HIJACK}; then


### PR DESCRIPTION
Make sure DIRS_emul is always defined. For MACHINE types other than
i386, amd64, evbearm* and evbpcc* this wasn't the case and buildrump.sh
was failing with an 'unbound variable' error.