### PR TITLE
Move unix sockets into /tmp.

### DIFF
--- a/tests/testrump.sh
+++ b/tests/testrump.sh
@@ -10,7 +10,7 @@ dosimpleclient ()
 {
 
 	printf 'Remote communication ... '
-	export RUMP_SERVER="unix://mysocket"
+	export RUMP_SERVER="unix:///tmp/mysocket"
 	${DESTDIR}/bin/rump_server "${RUMP_SERVER}" || die rump_server failed
 	./simpleclient || die simpleclient failed
 	unset RUMP_SERVER
@@ -68,12 +68,13 @@ donettest_routed ()
 
 	rm -f busmem1 busmem2
 	./nettest_routed server || die nettest server failed
-	./nettest_routed router unix://routerctrl || die router fail
+	./nettest_routed router unix:///tmp/routerctrl || die router fail
 	./nettest_routed client || die nettest client failed
 
 	# "code reuse ;)"
-	export RUMP_SERVER="unix://routerctrl"
+	export RUMP_SERVER="unix:///tmp/routerctrl"
 	${TESTOBJ}/simpleclient/simpleclient || die failed to reboot router
+	unset RUMP_SERVER
 	echo done
 }
 
@@ -84,12 +85,13 @@ donettest_routed6 ()
 
 	rm -f busmem1 busmem2
 	./nettest_routed6 server6 || die nettest server failed
-	./nettest_routed6 router6 unix://routerctrl || die router fail
+	./nettest_routed6 router6 unix:///tmp/routerctrl || die router fail
 	./nettest_routed6 client6 || die nettest client failed
 
 	# "code reuse ;)"
-	export RUMP_SERVER="unix://routerctrl"
+	export RUMP_SERVER="unix:///tmp/routerctrl"
 	${TESTOBJ}/simpleclient/simpleclient || die failed to reboot router
+	unset RUMP_SERVER
 	echo done
 }
 

--- a/tests/testrump.sh
+++ b/tests/testrump.sh
@@ -5,15 +5,16 @@
 
 TESTDIR=${BRDIR}/tests
 TESTOBJ=${OBJDIR}/brtests
+SOCKPATH="/tmp/testrump_socket.$$"
+SOCKURL="unix://${SOCKPATH}"
 
 dosimpleclient ()
 {
 
 	printf 'Remote communication ... '
-	export RUMP_SERVER="unix:///tmp/mysocket"
+	export RUMP_SERVER="${SOCKURL}"
 	${DESTDIR}/bin/rump_server "${RUMP_SERVER}" || die rump_server failed
 	./simpleclient || die simpleclient failed
-	unset RUMP_SERVER
 	echo done
 }
 
@@ -68,13 +69,12 @@ donettest_routed ()
 
 	rm -f busmem1 busmem2
 	./nettest_routed server || die nettest server failed
-	./nettest_routed router unix:///tmp/routerctrl || die router fail
+	./nettest_routed router "${SOCKURL}" || die router fail
 	./nettest_routed client || die nettest client failed
 
 	# "code reuse ;)"
-	export RUMP_SERVER="unix:///tmp/routerctrl"
+	export RUMP_SERVER="${SOCKURL}"
 	${TESTOBJ}/simpleclient/simpleclient || die failed to reboot router
-	unset RUMP_SERVER
 	echo done
 }
 
@@ -85,13 +85,12 @@ donettest_routed6 ()
 
 	rm -f busmem1 busmem2
 	./nettest_routed6 server6 || die nettest server failed
-	./nettest_routed6 router6 unix:///tmp/routerctrl || die router fail
+	./nettest_routed6 router6 "${SOCKURL}" || die router fail
 	./nettest_routed6 client6 || die nettest client failed
 
 	# "code reuse ;)"
-	export RUMP_SERVER="unix:///tmp/routerctrl"
+	export RUMP_SERVER="${SOCKURL}"
 	${TESTOBJ}/simpleclient/simpleclient || die failed to reboot router
-	unset RUMP_SERVER
 	echo done
 }
 
@@ -140,6 +139,7 @@ alltests ()
 			     dependall || exit 1
 		) && ( cd ${TO} ; do${test} )
 		failed=$(( ${failed} + $? ))
+		rm -f "${SOCKPATH}"
 	done
 
 	pkill -TERM -P $$


### PR DESCRIPTION
Suggestion:
3 tests failed in my environment because `rump server init failed: File name too long`.
Actually, the limit for a unix socket's path length is quite small. 
For example on NetBSD, according to unix(4) man page: 

> UNIX-domain addresses are variable-length filesystem pathnames of at most 104 characters.

while /usr/include/ufs/ffs/fs.h

> #define MAXMNTLEN       468

Can we put sockets in /tmp?
Or maybe it is kind of odd to patch this because  I work in paths far from /