### PR TITLE
Pass --allow-unrelated-histories to git merge if git version >= 2.9 where it is needed.

### DIFF
--- a/checkout.sh
+++ b/checkout.sh
@@ -259,15 +259,18 @@ githubdate ()
 	hubdateonebranch sys kernel
 	hubdateonebranch usr user
 
+	GIT_VERSION=`git --version | cut -d' ' -f 3`
+	version_le "2.9" "${GIT_VERSION}" && GIT_AUH="--allow-unrelated-histories"
+
 	${GIT} checkout appstack-src
-	${GIT} merge --no-edit kernel-src user-src
+	${GIT} merge --no-edit "${GIT_AUH}" kernel-src user-src
 
 	${GIT} checkout all-src
-	${GIT} merge --no-edit kernel-src user-src posix-src
+	${GIT} merge --no-edit "${GIT_AUH}" kernel-src user-src posix-src
 
 	# buildrump-src revision gets embedded in buildrump.sh
 	${GIT} checkout buildrump-src
-	${GIT} merge --no-edit kernel-src posix-src
+	${GIT} merge --no-edit "${GIT_AUH}" kernel-src posix-src
 	gitsrcrev=$(${GIT} rev-parse HEAD)
 
 	${GIT} checkout master

--- a/checkout.sh
+++ b/checkout.sh
@@ -263,14 +263,14 @@ githubdate ()
 	version_le "2.9" "${GIT_VERSION}" && GIT_AUH="--allow-unrelated-histories"
 
 	${GIT} checkout appstack-src
-	${GIT} merge --no-edit "${GIT_AUH}" kernel-src user-src
+	${GIT} merge --no-edit ${GIT_AUH} kernel-src user-src
 
 	${GIT} checkout all-src
-	${GIT} merge --no-edit "${GIT_AUH}" kernel-src user-src posix-src
+	${GIT} merge --no-edit ${GIT_AUH} kernel-src user-src posix-src
 
 	# buildrump-src revision gets embedded in buildrump.sh
 	${GIT} checkout buildrump-src
-	${GIT} merge --no-edit "${GIT_AUH}" kernel-src posix-src
+	${GIT} merge --no-edit ${GIT_AUH} kernel-src posix-src
 	gitsrcrev=$(${GIT} rev-parse HEAD)
 
 	${GIT} checkout master

--- a/subr.sh
+++ b/subr.sh
@@ -96,3 +96,21 @@ userincludes ()
 	done
 	echo '>> done installing headers'
 }
+
+version_le ()
+{
+	VS0="$1"
+	VS1="$2"
+	while true; do
+		vs0="${VS0%%.*}"
+		[ "${VS0}" = "${VS0#*.}" ] && VS0="" || VS0="${VS0#*.}"
+		vs1="${VS1%%.*}"
+		[ "${VS1}" = "${VS1#*.}" ] && VS1="" || VS1="${VS1#*.}"
+		[ "${vs0}" -lt "${vs1}" ] && return 0
+		[ "${vs0}" -gt "${vs1}" ] && return 1
+		[ -z "${VS0}" -a -z "${VS1}" ] && return 0
+		[ -z "${VS0}" ] && return 0
+		[ -z "${VS1}" ] && return 1
+	done
+}
+


### PR DESCRIPTION
While I was playing with checkout to try to update src-netbsd, git merge failed.
https://github.com/git/git/blob/master/Documentation/RelNotes/2.9.0.txt#L58-L68